### PR TITLE
Added web support

### DIFF
--- a/library/src/event-emitter.web.ts
+++ b/library/src/event-emitter.web.ts
@@ -1,0 +1,12 @@
+import { NativeEventEmitter } from 'react-native'
+
+import { DarkModeEventEmitter } from './dark-mode-event-emitter'
+
+export const eventEmitter = new DarkModeEventEmitter()
+
+
+var isDarkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+isDarkQuery.addListener((e) => {
+	eventEmitter.emit('currentModeChanged', e.matches ? 'dark' : 'light')
+})

--- a/library/src/initial-mode.web.ts
+++ b/library/src/initial-mode.web.ts
@@ -1,0 +1,11 @@
+import { Mode } from './types'
+
+const isDarkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+const isNoPreferenceQuery = window.matchMedia('(prefers-color-scheme: no-preference)');
+const isLightQuery = window.matchMedia('(prefers-color-scheme: light)');
+
+//should match one of the three
+const isSupported = isDarkQuery.matches || isNoPreferenceQuery.matches || isLightQuery.matches;
+
+export const initialMode: Mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+export const supportsDarkMode: boolean = isSupported;

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -1,1 +1,18 @@
 export type Mode = 'light' | 'dark'
+
+declare global {
+  interface MatchMediaEvent {
+    matches: boolean
+  }
+
+  interface MatchMedia {
+    addListener: (callback: (e: MatchMediaEvent) => void) => void
+    matches: boolean
+  }
+
+  interface Window {
+    matchMedia: (mediaQuery: string) => MatchMedia;
+  }
+
+  let window: Window
+}


### PR DESCRIPTION
This pull request adds support for web:

- Uses the CSS media-query `prefers-color-scheme` to establish whether Dark Mode is supported and/or enabled.
- Just like the iOS implementation it listens for changes and updates accordingly.
- Verified that it works in Safari and Firefox. It's live here: [Lyster](https://web.lyster.app/)
- Works with react-native-web, this means it should work seamlessly with Expo for Web as well (not verified).

I'm new to TypeScript - so I'm sure there's a better way to define the types than explicitly. But my simple attempt of adding "dom" to libraries in .tsconfig was unsuccessful.