### PR TITLE
Dark mode only supported on Android 10+

### DIFF
--- a/library/src/initial-mode.android.ts
+++ b/library/src/initial-mode.android.ts
@@ -1,0 +1,6 @@
+import { Platform } from 'react-native';
+import { NativeModule } from './native-module'
+import { Mode } from './types'
+
+export const initialMode: Mode = NativeModule.initialMode
+export const supportsDarkMode: boolean = NativeModule.supportsDarkMode && Platform.Version >= 29;


### PR DESCRIPTION
The simple solution for #17 - ie. only returning `supportsDarkMode = true`  on Android 10+.