### PR TITLE
Exporting types for dynamic styles

### DIFF
--- a/library/src/dynamic-style-sheet.ts
+++ b/library/src/dynamic-style-sheet.ts
@@ -12,6 +12,11 @@ type DynamicStyles<T> = { [P in keyof T]: DynamicStyle<Style> }
 
 type NormalizeStyle<T> = T extends DynamicStyle<infer R> ? R : T
 export type NormalizeStyles<T extends DynamicStyles<T>> = { [Key in keyof T]: NormalizeStyle<T[Key]> }
+						
+export type DynamicViewStyle = DynamicStyle<ViewStyle>
+export type DynamicTextStyle = DynamicStyle<TextStyle>
+export type DynamicImageStyle = DynamicStyle<ImageStyle>
+						
 
 function parseStylesFor<T extends DynamicStyles<T>>(styles: T, mode: Mode): NormalizeStyles<T> {
 	const newStyles: IndexedObject<IndexedObject<ValueOf<ValueOf<T>>>> = {}


### PR DESCRIPTION
This commit adds exports for 3 useful type declarations: `DynamicViewStyle`, `DynamicTextStyle`, and `DynamicImageStyle`. Exporting these types provides for better code completion when creating an instance of one of these styles. Example usage:

```typescript
const stylesheet = new DynamicStyleSheet({
    myViewStyle: {
      backgroundColor: new DynamicValue('#FFFFFF', '#000000')
    } as DynamicViewStyle,
    myTextStyle: {
      // ...
    } as DynamicTextStyle,
    myImageStyle: {
      // ...
    } as DynamicImageStyle
});