### PR TITLE
Fix for when appearance is changed after app launch, but before js ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ import { initialMode } from 'react-native-dark-mode'
 console.log('App started in', initialMode, 'mode')
 ```
 
+#### `currentMode`
+
+This is the current mode of the app.
+
+```javascript
+import { currentMode } from 'react-native-dark-mode'
+
+console.log('App is currently in', currentMode, 'mode')
+```
+
 #### `eventEmitter`
 
 Allows you to subscribe to changes in the mode.

--- a/library/android/src/main/java/com/codemotionapps/reactnativedarkmode/DarkModeModule.java
+++ b/library/android/src/main/java/com/codemotionapps/reactnativedarkmode/DarkModeModule.java
@@ -72,6 +72,10 @@ public class DarkModeModule extends ReactContextBaseJavaModule implements Lifecy
 		return constants;
 	}
 
+  public String currentMode () {
+		return reactContext.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+  }
+
 	@Override
 	public void onHostResume() {
 		this.notifyForChange();

--- a/library/ios/RNDarkMode.h
+++ b/library/ios/RNDarkMode.h
@@ -7,4 +7,6 @@
 
 - (void)currentModeChanged:(NSString *)newMode;
 
+- (NSString *)currentMode;
+
 @end

--- a/library/ios/RNDarkMode.m
+++ b/library/ios/RNDarkMode.m
@@ -33,6 +33,10 @@ RCT_EXPORT_MODULE();
 	};
 }
 
+- (NSString *)currentMode {
+	return [UIScreen getCurrentMode];
+}
+
 - (NSArray<NSString *> *)supportedEvents
 {
 	return @[@"currentModeChanged"];

--- a/library/src/dark-mode-event-emitter.ts
+++ b/library/src/dark-mode-event-emitter.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 
-import { initialMode } from './initial-mode'
+import { currentMode } from './initial-mode'
 import { Mode } from './types'
 
 export declare interface DarkModeEventEmitter {
@@ -10,7 +10,7 @@ export declare interface DarkModeEventEmitter {
 }
 
 export class DarkModeEventEmitter extends EventEmitter {
-	public currentMode: Mode = initialMode
+	public currentMode: Mode = currentMode
 
 	constructor() {
 		super()

--- a/library/src/initial-mode.ts
+++ b/library/src/initial-mode.ts
@@ -2,4 +2,5 @@ import { NativeModule } from './native-module'
 import { Mode } from './types'
 
 export const initialMode: Mode = NativeModule.initialMode
+export const currentMode: Mode = NativeModule.currentMode
 export const supportsDarkMode: boolean = NativeModule.supportsDarkMode


### PR DESCRIPTION
…ecution

I haven't written Java code for about 6 million years, so not sure how valid the Android change I;ve made is 🙈 

When the native iOS app is first started, the value `initialMode` is set. If the user then changes their appearance setting, this value is never subsequently updated as it is only set one time.

Therefore, if a user changes their appearance after initial app execution, but before JS code is executed, then the JS code will retrieve an outdated value for `initialMode`.

In the following example, the home screen is native code, whilst the hotels screen is react native code. The events happen in the following order, therefore:
 - Native app is launched, and `initialMode` is set to `Dark`
 - User changes appearance to `Light`. The event is not handled by RN code as it is not yet executing
 - User enters RN screen
 - RN reads value of `initialMode` which is still `Dark`

![gif](https://media.giphy.com/media/mBAkv0fUDg4W7m37Xr/giphy.gif)

I am proposing adding a value for `currentMode` which can be fetched when the JS code executes, which will return the current correct value.