### PR TITLE
Make dark mode library initially support web

### DIFF
--- a/library/src/initial-mode.ts
+++ b/library/src/initial-mode.ts
@@ -1,5 +1,5 @@
 import { NativeModule } from './native-module'
 import { Mode } from './types'
 
-export const initialMode: Mode = NativeModule.initialMode
-export const supportsDarkMode: boolean = NativeModule.supportsDarkMode
+export const initialMode: Mode = (NativeModule && NativeModule.initialMode) || 'light'
+export const supportsDarkMode: boolean = (NativeModule && NativeModule.supportsDarkMode) || false


### PR DESCRIPTION
This provides an early work on #9. This does not provide functionality for any of the dark mode detection (which I will be adding in a future release), but it does at least enable the package to be used with `react-native-web` without throwing an error. It's simply that it will be stuck on light mode for the time being